### PR TITLE
Allow func type param names in the field name subsection

### DIFF
--- a/document/core/appendix/custom.rst
+++ b/document/core/appendix/custom.rst
@@ -281,13 +281,16 @@ Field Names
 ...........
 
 The *field name subsection* has the id 10.
-It consists of an :ref:`indirect name map <binary-indirectnamemap>` assigning field names to :ref:`field indices <syntax-fieldidx>` grouped by the :ref:`type indices <syntax-typeidx>` of their respective :ref:`structure types <syntax-structtype>`.
+It consists of an :ref:`indirect name map <binary-indirectnamemap>` assigning parameter and field names to :ref:`field indices <syntax-fieldidx>` grouped by the :ref:`type indices <syntax-typeidx>` of their respective :ref:`composite types <syntax-comptype>`.
 
 .. math::
    \begin{array}{llclll}
    \production{field name subsection} & \Bfieldnamesubsec &::=&
      \Bnamesubsection_{10}(\Bindirectnamemap) \\
    \end{array}
+
+.. note::
+   All :ref:`composite types <syntax-comptype>` can be described by the field name subsection, not just :ref:`aggregate types <syntax-aggrtype>`.
 
 
 .. index:: tag, tag index

--- a/document/core/syntax/modules.rst
+++ b/document/core/syntax/modules.rst
@@ -84,7 +84,7 @@ The index space for :ref:`locals <syntax-local>` is only accessible inside a :re
 
 Label indices reference :ref:`structured control instructions <syntax-instr-control>` inside an instruction sequence. There are two index spaces for labels: one tracks the stack of active labels during validation, while the other tracks all labels defined in a specific function.
 
-Each :ref:`aggregate type <syntax-aggrtype>` provides an index space for its :ref:`fields <syntax-fieldtype>`.
+Each :ref:`composite type <syntax-comptype>` provides an index space for its :ref:`parameters <syntax-resulttype>` (for :ref:`function type <syntax-functype>`) or :ref:`fields <syntax-fieldtype>` (for :ref:`aggregate types <syntax-aggrtype>`). All such address spaces use :ref:`field indices <syntax-fieldidx>`.
 
 
 Conventions


### PR DESCRIPTION
It is very natural to extend the field name subsection to include parameters for function types. The binary encoding for function types would be identical, and func types are already included under "composite types" in the spec anyway.

In this patch I have updated to keep the name "field index" and "field name subsection" because "field" is the more natural name to use in most places in the spec. Renaming everything to "composite index" felt dramatically worse to me.

Resolves #4.