### PR TITLE
Add param name subsection

### DIFF
--- a/document/core/appendix/custom.rst
+++ b/document/core/appendix/custom.rst
@@ -55,7 +55,8 @@ Each subsection consists of:
      \Bdatanamesubsec^? \\ &&&
      \Bfieldnamesubsec^? \\ &&&
      \Btagnamesubsec^? \\ &&&
-     \Bparamnamesubsec^? \\
+     \Bparamnamesubsec^? \\ &&&
+     \Btagparamnamesubsec^? \\
    \production{name subsection} & \Bnamesubsection_N(\B{B}) &::=&
      N{:}\Bbyte~~\X{size}{:}\Bu32~~\B{B}
        & (\iff \X{size} = ||\B{B}||) \\
@@ -79,6 +80,7 @@ Id  Subsection
 10  :ref:`field names <binary-fieldnamesec>`
 11  :ref:`tag names <binary-tagnamesec>`
 12  :ref:`parameter names <binary-paramnamesec>`
+13  :ref:`tag parameter names <binary-tagparamnamesec>`
 ==  ===========================================
 
 Each subsection may occur at most once, and in order of increasing id.
@@ -156,6 +158,9 @@ Local Names
 
 The *local name subsection* has the id 2.
 It consists of an :ref:`indirect name map <binary-indirectnamemap>` assigning local names to :ref:`local indices <syntax-localidx>` grouped by :ref:`function indices <syntax-funcidx>`.
+
+.. note::
+    This includes the function's parameters, and can therefore be used for both defined and imported functions.
 
 .. math::
    \begin{array}{llclll}
@@ -317,12 +322,29 @@ Parameter Names
 The *parameter name subsection* has the id 12.
 It consists of an :ref:`indirect name map <binary-indirectnamemap>` assigning parameter names to parameter :ref:`indices <syntax-idx>` grouped by the :ref:`type indices <syntax-typeidx>` of their respective :ref:`function types <syntax-functype>`.
 
-Note that this section only names parameters within :ref:`function types <syntax-functype>`, not :ref:`type uses <syntax-typeuse>`. Per-function parameter names are assigned in the :ref:`local name subsection <binary-localnamesec>`.
+.. note::
+    This section only applies to :ref:`function types <syntax-functype>`, not :ref:`type uses <syntax-typeuse>`. Per-function parameter names are assigned in the :ref:`local name subsection <binary-localnamesec>`, and per-tag parameter names are assigned in the :ref:`tag parameter name subsection <binary-tagparamnamesec>`.
 
 .. math::
    \begin{array}{llclll}
    \production{parameter name subsection} & \Bparamnamesubsec &::=&
      \Bnamesubsection_{12}(\Bindirectnamemap) \\
+   \end{array}
+
+
+.. index:: tag, tag parameter, tag parameter index
+.. _binary-tagparamnamesec:
+
+Tag Parameter Names
+...................
+
+The *tag parameter name subsection* has the id 13.
+It consists of an :ref:`indirect name map <binary-indirectnamemap>` assigning parameter names to tag parameter :ref:`indices <syntax-idx>` grouped by their respective :ref:`tag indices <syntax-tagidx>`.
+
+.. math::
+   \begin{array}{llclll}
+   \production{tag parameter name subsection} & \Btagparamnamesubsec &::=&
+     \Bnamesubsection_{13}(\Bindirectnamemap) \\
    \end{array}
 
 

--- a/document/core/appendix/custom.rst
+++ b/document/core/appendix/custom.rst
@@ -5,7 +5,7 @@ Custom Sections and Annotations
 
 This appendix defines dedicated :ref:`custom sections <binary-customsec>` for WebAssembly's :ref:`binary format <binary>` and :ref:`annotations <text-annot>` for the text format.
 Such sections or annotations do not contribute to, or otherwise affect, the WebAssembly semantics, and may be ignored by an implementation.
-However, they provide useful meta data that implementations can make use of to improve user experience or take compilation hints.
+However, they provide useful metadata that implementations can make use of to improve user experience or take compilation hints.
 
 
 
@@ -31,7 +31,7 @@ Subsections
 ...........
 
 The :ref:`data <binary-customsec>` of a name section consists of a sequence of *subsections*.
-Each subsection consists of a
+Each subsection consists of:
 
 * a one-byte subsection *id*,
 * the |U32| *size* of the contents, in bytes,
@@ -54,7 +54,8 @@ Each subsection consists of a
      \Belemnamesubsec^? \\ &&&
      \Bdatanamesubsec^? \\ &&&
      \Bfieldnamesubsec^? \\ &&&
-     \Btagnamesubsec^? \\
+     \Btagnamesubsec^? \\ &&&
+     \Bparamnamesubsec^? \\
    \production{name subsection} & \Bnamesubsection_N(\B{B}) &::=&
      N{:}\Bbyte~~\X{size}{:}\Bu32~~\B{B}
        & (\iff \X{size} = ||\B{B}||) \\
@@ -77,6 +78,7 @@ Id  Subsection
  9  :ref:`data segment names <binary-datanamesec>`
 10  :ref:`field names <binary-fieldnamesec>`
 11  :ref:`tag names <binary-tagnamesec>`
+12  :ref:`parameter names <binary-paramnamesec>`
 ==  ===========================================
 
 Each subsection may occur at most once, and in order of increasing id.
@@ -303,6 +305,24 @@ It consists of a :ref:`name map <binary-namemap>` assigning tag names to :ref:`t
    \begin{array}{llclll}
    \production{tag name subsection} & \Btagnamesubsec &::=&
      \Bnamesubsection_{11}(\Bnamemap) \\
+   \end{array}
+
+
+.. index:: parameter, parameter index
+.. _binary-paramnamesec:
+
+Parameter Names
+...............
+
+The *parameter name subsection* has the id 12.
+It consists of an :ref:`indirect name map <binary-indirectnamemap>` assigning parameter names to parameter :ref:`indices <syntax-idx>` grouped by the :ref:`type indices <syntax-typeidx>` of their respective :ref:`function types <syntax-functype>`.
+
+Note that this section only names parameters within :ref:`function types <syntax-functype>`, not :ref:`type uses <syntax-typeuse>`. Per-function parameter names are assigned in the :ref:`local name subsection <binary-localnamesec>`.
+
+.. math::
+   \begin{array}{llclll}
+   \production{parameter name subsection} & \Bparamnamesubsec &::=&
+     \Bnamesubsection_{12}(\Bindirectnamemap) \\
    \end{array}
 
 

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -1824,6 +1824,7 @@
 .. |Bdatanamesubsec| mathdef:: \xref{appendix/custom}{binary-datanamesec}{\B{datanamesubsec}}
 .. |Bfieldnamesubsec| mathdef:: \xref{appendix/custom}{binary-fieldnamesec}{\B{fieldnamesubsec}}
 .. |Btagnamesubsec| mathdef:: \xref{appendix/custom}{binary-tagnamesec}{\B{tagnamesubsec}}
+.. |Bparamnamesubsec| mathdef:: \xref{appendix/custom}{binary-paramnamesec}{\B{paramnamesubsec}}
 
 
 .. Annotations

--- a/document/core/util/macros.def
+++ b/document/core/util/macros.def
@@ -1825,6 +1825,7 @@
 .. |Bfieldnamesubsec| mathdef:: \xref{appendix/custom}{binary-fieldnamesec}{\B{fieldnamesubsec}}
 .. |Btagnamesubsec| mathdef:: \xref{appendix/custom}{binary-tagnamesec}{\B{tagnamesubsec}}
 .. |Bparamnamesubsec| mathdef:: \xref{appendix/custom}{binary-paramnamesec}{\B{paramnamesubsec}}
+.. |Btagparamnamesubsec| mathdef:: \xref{appendix/custom}{binary-tagparamnamesec}{\B{tagparamnamesubsec}}
 
 
 .. Annotations

--- a/proposals/extended-name-section/Overview.md
+++ b/proposals/extended-name-section/Overview.md
@@ -18,6 +18,7 @@ The following new subsections are defined for the custom name section:
 | [global names](#global-names)                   | `7`  |
 | [element segment names](#element-segment-names) | `8`  |
 | [data segment names](#data-segment-names)       | `9`  |
+| [parameter names](#parameter-names)             | `12` |
 
 ### Label Names
 
@@ -44,3 +45,9 @@ The *element segment name subsection* has the id 8. It consists of a [name map](
 ### Data Segment Names
 
 The *data segment name subsection* has the id 9. It consists of a [name map](https://webassembly.github.io/spec/core/appendix/custom.html#binary-namemap) assigning data segment names to [data segment indices](https://webassembly.github.io/spec/core/binary/modules.html#binary-dataidx).
+
+### Parameter Names
+
+The *parameter name subsection* has the id 12. It consists of an [indirect name map](https://webassembly.github.io/spec/core/appendix/custom.html#binary-indirectnamemap) assigning parameter names to parameter indices grouped by [type indices](https://webassembly.github.io/spec/core/syntax/modules.html#syntax-typeidx).
+
+Note that this section assigns names to parameters in *function types*, not type uses (i.e. parameters written inline in function definitions or imports). Such parameters are already covered by the local name subsection.

--- a/proposals/extended-name-section/Overview.md
+++ b/proposals/extended-name-section/Overview.md
@@ -19,6 +19,7 @@ The following new subsections are defined for the custom name section:
 | [element segment names](#element-segment-names) | `8`  |
 | [data segment names](#data-segment-names)       | `9`  |
 | [parameter names](#parameter-names)             | `12` |
+| [tag parameter names](#tag-parameter-names)     | `13` |
 
 ### Label Names
 
@@ -48,6 +49,12 @@ The *data segment name subsection* has the id 9. It consists of a [name map](htt
 
 ### Parameter Names
 
-The *parameter name subsection* has the id 12. It consists of an [indirect name map](https://webassembly.github.io/spec/core/appendix/custom.html#binary-indirectnamemap) assigning parameter names to parameter indices grouped by [type indices](https://webassembly.github.io/spec/core/syntax/modules.html#syntax-typeidx).
+The *parameter name subsection* has the id 12. It consists of an [indirect name map](https://webassembly.github.io/spec/core/appendix/custom.html#binary-indirectnamemap) assigning parameter names to parameter indices grouped by [type indices](https://webassembly.github.io/spec/core/syntax/modules.html#syntax-typeidx) for function types.
 
 Note that this section assigns names to parameters in *function types*, not type uses (i.e. parameters written inline in function definitions or imports). Such parameters are already covered by the local name subsection.
+
+### Tag Parameter Names
+
+The *tag parameter name subsection* has the id 13. It consists of an [indirect name map](https://webassembly.github.io/spec/core/appendix/custom.html#binary-indirectnamemap) assigning parameter names to parameter indices grouped by [tag indices](https://webassembly.github.io/spec/core/syntax/modules.html#syntax-tagidx).
+
+This subsection exists because the names assigned to tag parameters belong to a type use, not a type definition, but because the type use is not associated with a function, the local name subsection cannot be used.


### PR DESCRIPTION
Adds a param name subsection specifically for parameters declared in function types.

Unlike #7, this PR simply adds a new subsection, rather than attempting to extend the behavior of the field name subsection. To me this feels more natural because it avoids confusion about index spaces, aggregate vs. composite types, etc. In particular, it avoids the need to define a new, proper index space that is only used for names, or to extend the definition of an existing address space in a similar way.

Resolves #4.
